### PR TITLE
fixes bug where puddle always runs in dev mode

### DIFF
--- a/puddle/puddle.go
+++ b/puddle/puddle.go
@@ -3,22 +3,23 @@ package puddle
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/nlopes/slack"
 	"log"
 	"os"
+
+	"github.com/nlopes/slack"
 )
 
 // SLACKTOKEN is the slack API token
 var SLACKTOKEN string
 
-// Current Git Tag
+// GITTAG is the current Git Tag
 var GITTAG string
 
 // CHANNEL is the Slack ID for channel #puddle
-var CHANNEL string = "C32K3QDFE"
+var CHANNEL = "C32K3QDFE"
 
 // ISDEV Whether Puddle is in Dev or CLI mode
-var ISDEV string = os.Getenv("PUDDLEDEV")
+var ISDEV = os.Getenv("PUDDLEDEV")
 
 var rtm *slack.RTM
 var slackAPI *slack.Client
@@ -27,8 +28,7 @@ var slackAPI *slack.Client
 // Connects to Slack & starts Slack API processing
 func Run(token, gittag string) {
 
-	if ISDEV == "true" || SLACKTOKEN == "" {
-		ISDEV = "true"
+	if ISDEV == "true" || token == "" {
 		RunCLI()
 		return
 	}


### PR DESCRIPTION
`Run()` was referring to the environment variable `SLACKTOKEN` which hasn't been parsed in this package yet so it was always an empty string. It should be referring to its argument, `token`.