### PR TITLE
Fix WriteChannel to actually send to the slack chan

### DIFF
--- a/messagerouter/response.go
+++ b/messagerouter/response.go
@@ -37,7 +37,7 @@ func (w *SlackResponseWriter) Rtm(rtm *slack.RTM) {
 
 // WriteChannel sends message to particular channel
 func (w *SlackResponseWriter) WriteChannel(channel string, text string) error {
-	w.rtm.SendMessage(w.rtm.NewOutgoingMessage(text, w.msg.Channel))
+	w.rtm.SendMessage(w.rtm.NewOutgoingMessage(text, channel))
 	return nil
 }
 


### PR DESCRIPTION
SlackResponseWriter.WriteChannel appears to be ignoring the channel argument?

But I thought it was in active use so I'm not sure what implications this has for production.